### PR TITLE
Use 365 days to compute date difference

### DIFF
--- a/feature/datecalculator/src/main/java/app/myzel394/numberhub/feature/datecalculator/difference/ZonedDateTimeDifference.kt
+++ b/feature/datecalculator/src/main/java/app/myzel394/numberhub/feature/datecalculator/difference/ZonedDateTimeDifference.kt
@@ -112,7 +112,7 @@ internal fun ZonedDateTime.minus(
     )
 }
 
-private val yearInSeconds by lazy { BigDecimal("31104000") }
+private val yearInSeconds by lazy { BigDecimal("31536000") }
 private val monthsInSeconds by lazy { BigDecimal("2592000") }
 private val dayInSeconds by lazy { BigDecimal("86400") }
 private val hourInSeconds by lazy { BigDecimal("3600") }


### PR DESCRIPTION
Closes #26

User also reported a discrepancy with the Months tab, but it may be an issue of months being counted as 30 days flat.